### PR TITLE
一定条件下で全ての要素が取り込まれるエラーを解決

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -38,25 +38,27 @@ class PostController extends Controller
         
         $query = Muscle::query();
         
-        if (!is_null($index_sex) && $index_sex != 0) {
-            $query->where('sex_id',$index_sex);
-        }
+        //if (!is_null($index_sex) && $index_sex != 0) {
+            $query->where('sex_id',$index_sex)->get();
+        //}
 
-        if (!is_null($index_objective) && $index_objective != 0) {
-            $query->where('objective_id',$index_objective);
-        }
+        //if (!is_null($index_objective) && $index_objective != 0) {
+            $query->where('objective_id',$index_objective)->get();
+        //}
 
-        if (!is_null($index_part) && $index_part != 0) {
-            $query->where('part_id',$index_part);
+        //if (!is_null($index_part) && $index_part != 0) {
+            $query->where('part_id',$index_part)->get();
            //$query = $query->where('part_id',$index_part);
-        }
+        //}
 
-        if (!is_null($index_equipment) && $index_equipment != 0) {
-            $query->where('equipment_id',$index_equipment);
-        }
+        //if (!is_null($index_equipment) && $index_equipment != 0) {
+            $query->where('equipment_id',$index_equipment)->get();
+        //}
         
-        $muscles = $query->get();
-        //$muscles = $query->orderBy('id', 'asc')->paginate(3);
+        //$muscles = $query->get();
+        $muscles = $query->orderBy('id', 'asc')->get();
+        //dd($muscles);
+        
         $training_sex = config('training_sex');
         $training_objective = config('training_objective');
         $training_part = config('training_part');
@@ -69,6 +71,7 @@ class PostController extends Controller
             "traning_equipment" => $training_equipment,
             "muscles" => $muscles,
         ];
+        //dd($muscles);
         return view('posts/menu',$data);
     }
 }

--- a/resources/views/posts/menu.blade.php
+++ b/resources/views/posts/menu.blade.php
@@ -6,13 +6,20 @@
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
     </head>
-<body>
-    <h1>メニュー</h1>
-            @foreach($muscles as $muscle)
-                <p>{{ $muscle->name->event_name }}</p>
-            @endforeach
-        @if (empty($muscles))
-            <p>トレーニングメニューはありませんでした。他の検索条件を試してみてください。</p>
-        @endif
-</body>
+    <body>
+        <h1>メニュー</h1>
+                @if($muscles->isempty())
+                
+                    <p>トレーニングメニューはありませんでした。他の検索条件を試してみてください。</p>
+                
+                @else
+        
+                    @foreach($muscles as $muscle)
+                        <p>{{ $muscle->name->event_name }}</p>
+                        <img src="{{ asset('image/' . $muscle->name->event_picture) }}" alt="トレーニング"> 
+                        <p>{{ $muscle->name->event_precautions }}</p>
+                    @endforeach
+            
+                @endif
+    </body>
 </html>


### PR DESCRIPTION
テーブルの条件と噛み合わない要素を選択した瞬間全てのテーブルが取り込まれるエラーを解決
上の場合再検索を促すメッセージを表示

@if(empty($muscles))
ではなく
@if($muscles->isempty())

にすると解決
理由はわからないのでこれから調べる